### PR TITLE
Fix compilation error: Replace deprecated FLASH_AREA_ID with FIXED_PA…

### DIFF
--- a/src/ota_manager.c
+++ b/src/ota_manager.c
@@ -10,7 +10,7 @@
 
 LOG_MODULE_REGISTER(ota_manager);
 
-#define FLASH_AREA_IMAGE_SECONDARY FLASH_AREA_ID(image_1)
+#define FLASH_AREA_IMAGE_SECONDARY FIXED_PARTITION_ID(slot1_partition)
 
 static const struct flash_area *flash_area;
 static size_t bytes_written = 0;


### PR DESCRIPTION
…RTITION_ID

- Updated ota_manager.c to use FIXED_PARTITION_ID(slot1_partition) instead of FLASH_AREA_ID(image_1)
- This fixes the compilation error where 'image_1' was undeclared
- The change aligns with modern Zephyr flash map API
- Resolves implicit declaration warning for FLASH_AREA_ID function